### PR TITLE
mark-devkit: [mark-xl] Bump virtual/commonlisp-0

### DIFF
--- a/virtual/commonlisp/commonlisp-0.ebuild
+++ b/virtual/commonlisp/commonlisp-0.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for Common Lisp"
+SLOT="0"
+KEYWORDS="alpha amd64 ia64 ppc ~sparc x86  ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~x86-solaris"
+
+RDEPEND="|| ( dev-lisp/sbcl
+	dev-lisp/clisp
+	dev-lisp/clozurecl
+	dev-lisp/cmucl
+	dev-lisp/ecls
+	dev-lisp/gcl
+	dev-lisp/abcl )"


### PR DESCRIPTION
Automatic bump of package virtual/commonlisp-0 for branch mark-xl by mark-bot